### PR TITLE
Experimentally consume Nimbus as a Swift Package

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -61,11 +61,9 @@
 		74F94FF21FD9CA070047E629 /* Intro.strings in Resources */ = {isa = PBXBuildFile; fileRef = 74F94FF41FD9CA070047E629 /* Intro.strings */; };
 		846A23182668CC4500DB3C37 /* FullScreen.js in Resources */ = {isa = PBXBuildFile; fileRef = 846A23172668CC4500DB3C37 /* FullScreen.js */; };
 		99335ED0268197A0009A0BAA /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = 99335ECF268197A0009A0BAA /* Glean */; };
-		993D6D4226AFE18E0075A820 /* Nimbus in Frameworks */ = {isa = PBXBuildFile; productRef = 993D6D4126AFE18E0075A820 /* Nimbus */; };
-		993D6D4426AFE18E0075A820 /* Viaduct in Frameworks */ = {isa = PBXBuildFile; productRef = 993D6D4326AFE18E0075A820 /* Viaduct */; };
-		993D6D4626AFE18E0075A820 /* RustLog in Frameworks */ = {isa = PBXBuildFile; productRef = 993D6D4526AFE18E0075A820 /* RustLog */; };
-		993D6D4826AFE18E0075A820 /* Logins in Frameworks */ = {isa = PBXBuildFile; productRef = 993D6D4726AFE18E0075A820 /* Logins */; };
-		993D6D4A26AFE18E0075A820 /* FxAClient in Frameworks */ = {isa = PBXBuildFile; productRef = 993D6D4926AFE18E0075A820 /* FxAClient */; };
+		99BC50AD26C3A2F300F1A6D5 /* RustLog in Frameworks */ = {isa = PBXBuildFile; productRef = 99BC50AC26C3A2F300F1A6D5 /* RustLog */; };
+		99BC50AF26C3A2F300F1A6D5 /* Nimbus in Frameworks */ = {isa = PBXBuildFile; productRef = 99BC50AE26C3A2F300F1A6D5 /* Nimbus */; };
+		99BC50B126C3A2F300F1A6D5 /* Viaduct in Frameworks */ = {isa = PBXBuildFile; productRef = 99BC50B026C3A2F300F1A6D5 /* Viaduct */; };
 		A89766DA1F57DCA9008183C5 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		B3481A551FCF261900CA2EA6 /* AutocompleteCustomUrlViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3481A541FCF261900CA2EA6 /* AutocompleteCustomUrlViewController.swift */; };
 		B3AFC2BC1F7C0B9F001AEF38 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AFC2BB1F7C0B9F001AEF38 /* WebViewController.swift */; };
@@ -952,16 +950,14 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				99BC50AF26C3A2F300F1A6D5 /* Nimbus in Frameworks */,
 				F85F7A292655AD5800395515 /* SnapKit in Frameworks */,
 				F85F7A2F2655AD5800395515 /* Telemetry in Frameworks */,
 				F85F7A2B2655AD5800395515 /* Fuzi in Frameworks */,
+				99BC50AD26C3A2F300F1A6D5 /* RustLog in Frameworks */,
 				F85F7A2D2655AD5800395515 /* Sentry in Frameworks */,
-				993D6D4426AFE18E0075A820 /* Viaduct in Frameworks */,
-				993D6D4226AFE18E0075A820 /* Nimbus in Frameworks */,
-				993D6D4826AFE18E0075A820 /* Logins in Frameworks */,
 				99335ED0268197A0009A0BAA /* Glean in Frameworks */,
-				993D6D4626AFE18E0075A820 /* RustLog in Frameworks */,
-				993D6D4A26AFE18E0075A820 /* FxAClient in Frameworks */,
+				99BC50B126C3A2F300F1A6D5 /* Viaduct in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1458,11 +1454,9 @@
 				F85F7A2C2655AD5800395515 /* Sentry */,
 				F85F7A2E2655AD5800395515 /* Telemetry */,
 				99335ECF268197A0009A0BAA /* Glean */,
-				993D6D4126AFE18E0075A820 /* Nimbus */,
-				993D6D4326AFE18E0075A820 /* Viaduct */,
-				993D6D4526AFE18E0075A820 /* RustLog */,
-				993D6D4726AFE18E0075A820 /* Logins */,
-				993D6D4926AFE18E0075A820 /* FxAClient */,
+				99BC50AC26C3A2F300F1A6D5 /* RustLog */,
+				99BC50AE26C3A2F300F1A6D5 /* Nimbus */,
+				99BC50B026C3A2F300F1A6D5 /* Viaduct */,
 			);
 			productName = Blockzilla;
 			productReference = E4BF2DD31BACE8CA00DA9D68 /* Firefox Klar.app */;
@@ -1636,7 +1630,7 @@
 				F8324C76264DA5F1007E4BFA /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				F8324E0726556E45007E4BFA /* XCRemoteSwiftPackageReference "telemetry-ios" */,
 				99335ECE268197A0009A0BAA /* XCRemoteSwiftPackageReference "glean-swift" */,
-				993D6D4026AFE18E0075A820 /* XCRemoteSwiftPackageReference "rust-components-swift" */,
+				99BC50AB26C3A2F300F1A6D5 /* XCRemoteSwiftPackageReference "rust-components-swift" */,
 			);
 			productRefGroup = E4BF2DD41BACE8CA00DA9D68 /* Products */;
 			projectDirPath = "";
@@ -5143,12 +5137,12 @@
 				minimumVersion = 39.0.0;
 			};
 		};
-		993D6D4026AFE18E0075A820 /* XCRemoteSwiftPackageReference "rust-components-swift" */ = {
+		99BC50AB26C3A2F300F1A6D5 /* XCRemoteSwiftPackageReference "rust-components-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/rfk/rust-components-swift";
+			repositoryURL = "file:///Users/rfk/repos/mozilla/rust-components-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.0;
+				minimumVersion = 0.3.0;
 			};
 		};
 		F8324C2D264C807C007E4BFA /* XCRemoteSwiftPackageReference "SnapKit" */ = {
@@ -5191,30 +5185,20 @@
 			package = 99335ECE268197A0009A0BAA /* XCRemoteSwiftPackageReference "glean-swift" */;
 			productName = Glean;
 		};
-		993D6D4126AFE18E0075A820 /* Nimbus */ = {
+		99BC50AC26C3A2F300F1A6D5 /* RustLog */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 993D6D4026AFE18E0075A820 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
-			productName = Nimbus;
-		};
-		993D6D4326AFE18E0075A820 /* Viaduct */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 993D6D4026AFE18E0075A820 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
-			productName = Viaduct;
-		};
-		993D6D4526AFE18E0075A820 /* RustLog */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 993D6D4026AFE18E0075A820 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
+			package = 99BC50AB26C3A2F300F1A6D5 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
 			productName = RustLog;
 		};
-		993D6D4726AFE18E0075A820 /* Logins */ = {
+		99BC50AE26C3A2F300F1A6D5 /* Nimbus */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 993D6D4026AFE18E0075A820 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
-			productName = Logins;
+			package = 99BC50AB26C3A2F300F1A6D5 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
+			productName = Nimbus;
 		};
-		993D6D4926AFE18E0075A820 /* FxAClient */ = {
+		99BC50B026C3A2F300F1A6D5 /* Viaduct */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 993D6D4026AFE18E0075A820 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
-			productName = FxAClient;
+			package = 99BC50AB26C3A2F300F1A6D5 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
+			productName = Viaduct;
 		};
 		F85F7A282655AD5800395515 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -60,6 +60,10 @@
 		747ADA181FC38EFC00970132 /* IntroViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747ADA171FC38EFC00970132 /* IntroViewController.swift */; };
 		74F94FF21FD9CA070047E629 /* Intro.strings in Resources */ = {isa = PBXBuildFile; fileRef = 74F94FF41FD9CA070047E629 /* Intro.strings */; };
 		846A23182668CC4500DB3C37 /* FullScreen.js in Resources */ = {isa = PBXBuildFile; fileRef = 846A23172668CC4500DB3C37 /* FullScreen.js */; };
+		99335ED0268197A0009A0BAA /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = 99335ECF268197A0009A0BAA /* Glean */; };
+		99B77DE026829B70007BAE3F /* RustLog in Frameworks */ = {isa = PBXBuildFile; productRef = 99B77DDF26829B70007BAE3F /* RustLog */; };
+		99B77DE226829B70007BAE3F /* Viaduct in Frameworks */ = {isa = PBXBuildFile; productRef = 99B77DE126829B70007BAE3F /* Viaduct */; };
+		99B77DE426829B70007BAE3F /* Nimbus in Frameworks */ = {isa = PBXBuildFile; productRef = 99B77DE326829B70007BAE3F /* Nimbus */; };
 		A89766DA1F57DCA9008183C5 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		B3481A551FCF261900CA2EA6 /* AutocompleteCustomUrlViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3481A541FCF261900CA2EA6 /* AutocompleteCustomUrlViewController.swift */; };
 		B3AFC2BC1F7C0B9F001AEF38 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AFC2BB1F7C0B9F001AEF38 /* WebViewController.swift */; };
@@ -178,7 +182,6 @@
 		F85F7A2B2655AD5800395515 /* Fuzi in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A2A2655AD5800395515 /* Fuzi */; };
 		F85F7A2D2655AD5800395515 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A2C2655AD5800395515 /* Sentry */; };
 		F85F7A2F2655AD5800395515 /* Telemetry in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A2E2655AD5800395515 /* Telemetry */; };
-		F85F7A352656885C00395515 /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A342656885C00395515 /* Glean */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -950,8 +953,11 @@
 				F85F7A292655AD5800395515 /* SnapKit in Frameworks */,
 				F85F7A2F2655AD5800395515 /* Telemetry in Frameworks */,
 				F85F7A2B2655AD5800395515 /* Fuzi in Frameworks */,
+				99B77DE026829B70007BAE3F /* RustLog in Frameworks */,
+				99B77DE426829B70007BAE3F /* Nimbus in Frameworks */,
+				99B77DE226829B70007BAE3F /* Viaduct in Frameworks */,
 				F85F7A2D2655AD5800395515 /* Sentry in Frameworks */,
-				F85F7A352656885C00395515 /* Glean in Frameworks */,
+				99335ED0268197A0009A0BAA /* Glean in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1447,7 +1453,10 @@
 				F85F7A2A2655AD5800395515 /* Fuzi */,
 				F85F7A2C2655AD5800395515 /* Sentry */,
 				F85F7A2E2655AD5800395515 /* Telemetry */,
-				F85F7A342656885C00395515 /* Glean */,
+				99335ECF268197A0009A0BAA /* Glean */,
+				99B77DDF26829B70007BAE3F /* RustLog */,
+				99B77DE126829B70007BAE3F /* Viaduct */,
+				99B77DE326829B70007BAE3F /* Nimbus */,
 			);
 			productName = Blockzilla;
 			productReference = E4BF2DD31BACE8CA00DA9D68 /* Firefox Klar.app */;
@@ -1620,7 +1629,8 @@
 				F8324CB8264DC8ED007E4BFA /* XCRemoteSwiftPackageReference "Fuzi" */,
 				F8324C76264DA5F1007E4BFA /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				F8324E0726556E45007E4BFA /* XCRemoteSwiftPackageReference "telemetry-ios" */,
-				F85F7A332656885C00395515 /* XCRemoteSwiftPackageReference "glean-swift" */,
+				99335ECE268197A0009A0BAA /* XCRemoteSwiftPackageReference "glean-swift" */,
+				99B77DDE26829B70007BAE3F /* XCRemoteSwiftPackageReference "rust-components-swift" */,
 			);
 			productRefGroup = E4BF2DD41BACE8CA00DA9D68 /* Products */;
 			projectDirPath = "";
@@ -5119,6 +5129,22 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		99335ECE268197A0009A0BAA /* XCRemoteSwiftPackageReference "glean-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mozilla/glean-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 38.0.0;
+			};
+		};
+		99B77DDE26829B70007BAE3F /* XCRemoteSwiftPackageReference "rust-components-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/rfk/rust-components-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.3;
+			};
+		};
 		F8324C2D264C807C007E4BFA /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit";
@@ -5151,17 +5177,29 @@
 				kind = branch;
 			};
 		};
-		F85F7A332656885C00395515 /* XCRemoteSwiftPackageReference "glean-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mozilla/glean-swift/";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 39.0.2;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		99335ECF268197A0009A0BAA /* Glean */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 99335ECE268197A0009A0BAA /* XCRemoteSwiftPackageReference "glean-swift" */;
+			productName = Glean;
+		};
+		99B77DDF26829B70007BAE3F /* RustLog */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 99B77DDE26829B70007BAE3F /* XCRemoteSwiftPackageReference "rust-components-swift" */;
+			productName = RustLog;
+		};
+		99B77DE126829B70007BAE3F /* Viaduct */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 99B77DDE26829B70007BAE3F /* XCRemoteSwiftPackageReference "rust-components-swift" */;
+			productName = Viaduct;
+		};
+		99B77DE326829B70007BAE3F /* Nimbus */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 99B77DDE26829B70007BAE3F /* XCRemoteSwiftPackageReference "rust-components-swift" */;
+			productName = Nimbus;
+		};
 		F85F7A282655AD5800395515 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F8324C2D264C807C007E4BFA /* XCRemoteSwiftPackageReference "SnapKit" */;
@@ -5181,11 +5219,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F8324E0726556E45007E4BFA /* XCRemoteSwiftPackageReference "telemetry-ios" */;
 			productName = Telemetry;
-		};
-		F85F7A342656885C00395515 /* Glean */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F85F7A332656885C00395515 /* XCRemoteSwiftPackageReference "glean-swift" */;
-			productName = Glean;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -61,9 +61,9 @@
 		74F94FF21FD9CA070047E629 /* Intro.strings in Resources */ = {isa = PBXBuildFile; fileRef = 74F94FF41FD9CA070047E629 /* Intro.strings */; };
 		846A23182668CC4500DB3C37 /* FullScreen.js in Resources */ = {isa = PBXBuildFile; fileRef = 846A23172668CC4500DB3C37 /* FullScreen.js */; };
 		99335ED0268197A0009A0BAA /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = 99335ECF268197A0009A0BAA /* Glean */; };
-		99BC50AD26C3A2F300F1A6D5 /* RustLog in Frameworks */ = {isa = PBXBuildFile; productRef = 99BC50AC26C3A2F300F1A6D5 /* RustLog */; };
-		99BC50AF26C3A2F300F1A6D5 /* Nimbus in Frameworks */ = {isa = PBXBuildFile; productRef = 99BC50AE26C3A2F300F1A6D5 /* Nimbus */; };
-		99BC50B126C3A2F300F1A6D5 /* Viaduct in Frameworks */ = {isa = PBXBuildFile; productRef = 99BC50B026C3A2F300F1A6D5 /* Viaduct */; };
+		99F9B8E926C3AB7B0047F708 /* RustLog in Frameworks */ = {isa = PBXBuildFile; productRef = 99F9B8E826C3AB7B0047F708 /* RustLog */; };
+		99F9B8EB26C3AB7B0047F708 /* Viaduct in Frameworks */ = {isa = PBXBuildFile; productRef = 99F9B8EA26C3AB7B0047F708 /* Viaduct */; };
+		99F9B8ED26C3AB7B0047F708 /* Nimbus in Frameworks */ = {isa = PBXBuildFile; productRef = 99F9B8EC26C3AB7B0047F708 /* Nimbus */; };
 		A89766DA1F57DCA9008183C5 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		B3481A551FCF261900CA2EA6 /* AutocompleteCustomUrlViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3481A541FCF261900CA2EA6 /* AutocompleteCustomUrlViewController.swift */; };
 		B3AFC2BC1F7C0B9F001AEF38 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AFC2BB1F7C0B9F001AEF38 /* WebViewController.swift */; };
@@ -950,14 +950,14 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				99BC50AF26C3A2F300F1A6D5 /* Nimbus in Frameworks */,
 				F85F7A292655AD5800395515 /* SnapKit in Frameworks */,
 				F85F7A2F2655AD5800395515 /* Telemetry in Frameworks */,
 				F85F7A2B2655AD5800395515 /* Fuzi in Frameworks */,
-				99BC50AD26C3A2F300F1A6D5 /* RustLog in Frameworks */,
+				99F9B8E926C3AB7B0047F708 /* RustLog in Frameworks */,
+				99F9B8ED26C3AB7B0047F708 /* Nimbus in Frameworks */,
+				99F9B8EB26C3AB7B0047F708 /* Viaduct in Frameworks */,
 				F85F7A2D2655AD5800395515 /* Sentry in Frameworks */,
 				99335ED0268197A0009A0BAA /* Glean in Frameworks */,
-				99BC50B126C3A2F300F1A6D5 /* Viaduct in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1454,9 +1454,9 @@
 				F85F7A2C2655AD5800395515 /* Sentry */,
 				F85F7A2E2655AD5800395515 /* Telemetry */,
 				99335ECF268197A0009A0BAA /* Glean */,
-				99BC50AC26C3A2F300F1A6D5 /* RustLog */,
-				99BC50AE26C3A2F300F1A6D5 /* Nimbus */,
-				99BC50B026C3A2F300F1A6D5 /* Viaduct */,
+				99F9B8E826C3AB7B0047F708 /* RustLog */,
+				99F9B8EA26C3AB7B0047F708 /* Viaduct */,
+				99F9B8EC26C3AB7B0047F708 /* Nimbus */,
 			);
 			productName = Blockzilla;
 			productReference = E4BF2DD31BACE8CA00DA9D68 /* Firefox Klar.app */;
@@ -1630,7 +1630,7 @@
 				F8324C76264DA5F1007E4BFA /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				F8324E0726556E45007E4BFA /* XCRemoteSwiftPackageReference "telemetry-ios" */,
 				99335ECE268197A0009A0BAA /* XCRemoteSwiftPackageReference "glean-swift" */,
-				99BC50AB26C3A2F300F1A6D5 /* XCRemoteSwiftPackageReference "rust-components-swift" */,
+				99F9B8E726C3AB7B0047F708 /* XCRemoteSwiftPackageReference "rust-components-swift" */,
 			);
 			productRefGroup = E4BF2DD41BACE8CA00DA9D68 /* Products */;
 			projectDirPath = "";
@@ -5137,12 +5137,12 @@
 				minimumVersion = 39.0.0;
 			};
 		};
-		99BC50AB26C3A2F300F1A6D5 /* XCRemoteSwiftPackageReference "rust-components-swift" */ = {
+		99F9B8E726C3AB7B0047F708 /* XCRemoteSwiftPackageReference "rust-components-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "file:///Users/rfk/repos/mozilla/rust-components-swift";
+			repositoryURL = "https://github.com/mozilla/rust-components-swift";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.0;
+				kind = exactVersion;
+				version = 0.0.1;
 			};
 		};
 		F8324C2D264C807C007E4BFA /* XCRemoteSwiftPackageReference "SnapKit" */ = {
@@ -5185,20 +5185,20 @@
 			package = 99335ECE268197A0009A0BAA /* XCRemoteSwiftPackageReference "glean-swift" */;
 			productName = Glean;
 		};
-		99BC50AC26C3A2F300F1A6D5 /* RustLog */ = {
+		99F9B8E826C3AB7B0047F708 /* RustLog */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 99BC50AB26C3A2F300F1A6D5 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
+			package = 99F9B8E726C3AB7B0047F708 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
 			productName = RustLog;
 		};
-		99BC50AE26C3A2F300F1A6D5 /* Nimbus */ = {
+		99F9B8EA26C3AB7B0047F708 /* Viaduct */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 99BC50AB26C3A2F300F1A6D5 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
-			productName = Nimbus;
-		};
-		99BC50B026C3A2F300F1A6D5 /* Viaduct */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 99BC50AB26C3A2F300F1A6D5 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
+			package = 99F9B8E726C3AB7B0047F708 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
 			productName = Viaduct;
+		};
+		99F9B8EC26C3AB7B0047F708 /* Nimbus */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 99F9B8E726C3AB7B0047F708 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
+			productName = Nimbus;
 		};
 		F85F7A282655AD5800395515 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -61,9 +61,11 @@
 		74F94FF21FD9CA070047E629 /* Intro.strings in Resources */ = {isa = PBXBuildFile; fileRef = 74F94FF41FD9CA070047E629 /* Intro.strings */; };
 		846A23182668CC4500DB3C37 /* FullScreen.js in Resources */ = {isa = PBXBuildFile; fileRef = 846A23172668CC4500DB3C37 /* FullScreen.js */; };
 		99335ED0268197A0009A0BAA /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = 99335ECF268197A0009A0BAA /* Glean */; };
-		99B77DE026829B70007BAE3F /* RustLog in Frameworks */ = {isa = PBXBuildFile; productRef = 99B77DDF26829B70007BAE3F /* RustLog */; };
-		99B77DE226829B70007BAE3F /* Viaduct in Frameworks */ = {isa = PBXBuildFile; productRef = 99B77DE126829B70007BAE3F /* Viaduct */; };
-		99B77DE426829B70007BAE3F /* Nimbus in Frameworks */ = {isa = PBXBuildFile; productRef = 99B77DE326829B70007BAE3F /* Nimbus */; };
+		993D6D4226AFE18E0075A820 /* Nimbus in Frameworks */ = {isa = PBXBuildFile; productRef = 993D6D4126AFE18E0075A820 /* Nimbus */; };
+		993D6D4426AFE18E0075A820 /* Viaduct in Frameworks */ = {isa = PBXBuildFile; productRef = 993D6D4326AFE18E0075A820 /* Viaduct */; };
+		993D6D4626AFE18E0075A820 /* RustLog in Frameworks */ = {isa = PBXBuildFile; productRef = 993D6D4526AFE18E0075A820 /* RustLog */; };
+		993D6D4826AFE18E0075A820 /* Logins in Frameworks */ = {isa = PBXBuildFile; productRef = 993D6D4726AFE18E0075A820 /* Logins */; };
+		993D6D4A26AFE18E0075A820 /* FxAClient in Frameworks */ = {isa = PBXBuildFile; productRef = 993D6D4926AFE18E0075A820 /* FxAClient */; };
 		A89766DA1F57DCA9008183C5 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		B3481A551FCF261900CA2EA6 /* AutocompleteCustomUrlViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3481A541FCF261900CA2EA6 /* AutocompleteCustomUrlViewController.swift */; };
 		B3AFC2BC1F7C0B9F001AEF38 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AFC2BB1F7C0B9F001AEF38 /* WebViewController.swift */; };
@@ -953,11 +955,13 @@
 				F85F7A292655AD5800395515 /* SnapKit in Frameworks */,
 				F85F7A2F2655AD5800395515 /* Telemetry in Frameworks */,
 				F85F7A2B2655AD5800395515 /* Fuzi in Frameworks */,
-				99B77DE026829B70007BAE3F /* RustLog in Frameworks */,
-				99B77DE426829B70007BAE3F /* Nimbus in Frameworks */,
-				99B77DE226829B70007BAE3F /* Viaduct in Frameworks */,
 				F85F7A2D2655AD5800395515 /* Sentry in Frameworks */,
+				993D6D4426AFE18E0075A820 /* Viaduct in Frameworks */,
+				993D6D4226AFE18E0075A820 /* Nimbus in Frameworks */,
+				993D6D4826AFE18E0075A820 /* Logins in Frameworks */,
 				99335ED0268197A0009A0BAA /* Glean in Frameworks */,
+				993D6D4626AFE18E0075A820 /* RustLog in Frameworks */,
+				993D6D4A26AFE18E0075A820 /* FxAClient in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1454,9 +1458,11 @@
 				F85F7A2C2655AD5800395515 /* Sentry */,
 				F85F7A2E2655AD5800395515 /* Telemetry */,
 				99335ECF268197A0009A0BAA /* Glean */,
-				99B77DDF26829B70007BAE3F /* RustLog */,
-				99B77DE126829B70007BAE3F /* Viaduct */,
-				99B77DE326829B70007BAE3F /* Nimbus */,
+				993D6D4126AFE18E0075A820 /* Nimbus */,
+				993D6D4326AFE18E0075A820 /* Viaduct */,
+				993D6D4526AFE18E0075A820 /* RustLog */,
+				993D6D4726AFE18E0075A820 /* Logins */,
+				993D6D4926AFE18E0075A820 /* FxAClient */,
 			);
 			productName = Blockzilla;
 			productReference = E4BF2DD31BACE8CA00DA9D68 /* Firefox Klar.app */;
@@ -1630,7 +1636,7 @@
 				F8324C76264DA5F1007E4BFA /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				F8324E0726556E45007E4BFA /* XCRemoteSwiftPackageReference "telemetry-ios" */,
 				99335ECE268197A0009A0BAA /* XCRemoteSwiftPackageReference "glean-swift" */,
-				99B77DDE26829B70007BAE3F /* XCRemoteSwiftPackageReference "rust-components-swift" */,
+				993D6D4026AFE18E0075A820 /* XCRemoteSwiftPackageReference "rust-components-swift" */,
 			);
 			productRefGroup = E4BF2DD41BACE8CA00DA9D68 /* Products */;
 			projectDirPath = "";
@@ -5134,15 +5140,15 @@
 			repositoryURL = "https://github.com/mozilla/glean-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 38.0.0;
+				minimumVersion = 39.0.0;
 			};
 		};
-		99B77DDE26829B70007BAE3F /* XCRemoteSwiftPackageReference "rust-components-swift" */ = {
+		993D6D4026AFE18E0075A820 /* XCRemoteSwiftPackageReference "rust-components-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/rfk/rust-components-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.3;
+				minimumVersion = 0.2.0;
 			};
 		};
 		F8324C2D264C807C007E4BFA /* XCRemoteSwiftPackageReference "SnapKit" */ = {
@@ -5185,20 +5191,30 @@
 			package = 99335ECE268197A0009A0BAA /* XCRemoteSwiftPackageReference "glean-swift" */;
 			productName = Glean;
 		};
-		99B77DDF26829B70007BAE3F /* RustLog */ = {
+		993D6D4126AFE18E0075A820 /* Nimbus */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 99B77DDE26829B70007BAE3F /* XCRemoteSwiftPackageReference "rust-components-swift" */;
-			productName = RustLog;
+			package = 993D6D4026AFE18E0075A820 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
+			productName = Nimbus;
 		};
-		99B77DE126829B70007BAE3F /* Viaduct */ = {
+		993D6D4326AFE18E0075A820 /* Viaduct */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 99B77DDE26829B70007BAE3F /* XCRemoteSwiftPackageReference "rust-components-swift" */;
+			package = 993D6D4026AFE18E0075A820 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
 			productName = Viaduct;
 		};
-		99B77DE326829B70007BAE3F /* Nimbus */ = {
+		993D6D4526AFE18E0075A820 /* RustLog */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 99B77DDE26829B70007BAE3F /* XCRemoteSwiftPackageReference "rust-components-swift" */;
-			productName = Nimbus;
+			package = 993D6D4026AFE18E0075A820 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
+			productName = RustLog;
+		};
+		993D6D4726AFE18E0075A820 /* Logins */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 993D6D4026AFE18E0075A820 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
+			productName = Logins;
+		};
+		993D6D4926AFE18E0075A820 /* FxAClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 993D6D4026AFE18E0075A820 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
+			productName = FxAClient;
 		};
 		F85F7A282655AD5800395515 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mozilla/glean-swift",
         "state": {
           "branch": null,
-          "revision": "bfc206651ba8559f6c54f51dd7d6561dc07531f4",
-          "version": "38.0.2"
+          "revision": "4c27428820ef28d7572ab4b63fb5ae7b88ce2a78",
+          "version": "39.1.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/rfk/rust-components-swift",
         "state": {
           "branch": null,
-          "revision": "0b6e716b7942b38d2eefd55a9119c265d8d8d21d",
-          "version": "0.1.3"
+          "revision": "a360a0a6138a9355c5ebfdf871e37fd8c7147a7f",
+          "version": "0.2.0"
         }
       },
       {
@@ -44,6 +44,15 @@
           "branch": null,
           "revision": "d458564516e5676af9c70b4f4b2a9178294f1bc6",
           "version": "5.0.1"
+        }
+      },
+      {
+        "package": "SwiftKeychainWrapper",
+        "repositoryURL": "https://github.com/jrendel/SwiftKeychainWrapper",
+        "state": {
+          "branch": null,
+          "revision": "185a3165346a03767101c4f62e9a545a0fe0530f",
+          "version": "4.0.1"
         }
       },
       {

--- a/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -21,11 +21,11 @@
       },
       {
         "package": "MozillaRustComponentsSwift",
-        "repositoryURL": "/Users/rfk/repos/mozilla/rust-components-swift",
+        "repositoryURL": "https://github.com/mozilla/rust-components-swift",
         "state": {
           "branch": null,
-          "revision": "857c67d877069f209747bcc640ca32f5b2591383",
-          "version": "0.3.0"
+          "revision": "c0a8a30b3637b0eac5992f0b445632de46256e63",
+          "version": "0.0.1"
         }
       },
       {

--- a/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -12,11 +12,20 @@
       },
       {
         "package": "Glean",
-        "repositoryURL": "https://github.com/mozilla/glean-swift/",
+        "repositoryURL": "https://github.com/mozilla/glean-swift",
         "state": {
           "branch": null,
-          "revision": "e6c2d31b128be4fc59cdaf684acfbb419454866a",
-          "version": "39.0.2"
+          "revision": "bfc206651ba8559f6c54f51dd7d6561dc07531f4",
+          "version": "38.0.2"
+        }
+      },
+      {
+        "package": "MozillaRustComponentsSwift",
+        "repositoryURL": "https://github.com/rfk/rust-components-swift",
+        "state": {
+          "branch": null,
+          "revision": "0b6e716b7942b38d2eefd55a9119c265d8d8d21d",
+          "version": "0.1.3"
         }
       },
       {

--- a/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -21,11 +21,11 @@
       },
       {
         "package": "MozillaRustComponentsSwift",
-        "repositoryURL": "https://github.com/rfk/rust-components-swift",
+        "repositoryURL": "/Users/rfk/repos/mozilla/rust-components-swift",
         "state": {
           "branch": null,
-          "revision": "a360a0a6138a9355c5ebfdf871e37fd8c7147a7f",
-          "version": "0.2.0"
+          "revision": "857c67d877069f209747bcc640ca32f5b2591383",
+          "version": "0.3.0"
         }
       },
       {
@@ -44,15 +44,6 @@
           "branch": null,
           "revision": "d458564516e5676af9c70b4f4b2a9178294f1bc6",
           "version": "5.0.1"
-        }
-      },
-      {
-        "package": "SwiftKeychainWrapper",
-        "repositoryURL": "https://github.com/jrendel/SwiftKeychainWrapper",
-        "state": {
-          "branch": null,
-          "revision": "185a3165346a03767101c4f62e9a545a0fe0530f",
-          "version": "4.0.1"
         }
       },
       {

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -5,11 +5,12 @@
 import UIKit
 import Telemetry
 import Glean
-import Nimbus
-import FxAClient
-import Logins
 import Viaduct
 import RustLog
+import Nimbus
+// TODO: for future testing of other components
+//import FxAClient
+//import Logins
 
 protocol AppSplashController {
     var splashView: UIView { get }
@@ -447,38 +448,39 @@ extension AppDelegate {
         myNimbus.initialize()
         myNimbus.fetchExperiments()
         
+        // TODO: for future testing of other components.
         // Try to create an FxA Client object
-        let fxa = FirefoxAccount(
-            contentUrl: "https://accounts.firefox.com",
-            clientId: "junk",
-            redirectUri: "junk",
-            tokenServerUrlOverride: nil
-        )
-        print("fxa oauth URL: " + (try! fxa.beginOauthFlow(scopes: ["profile"], entrypoint: "junk", metrics: nil)))
-        
+        //let fxa = FirefoxAccount(
+        //    contentUrl: "https://accounts.firefox.com",
+        //    clientId: "junk",
+        //    redirectUri: "junk",
+        //    tokenServerUrlOverride: nil
+        //)
+        //print("fxa oauth URL: " + (try! fxa.beginOauthFlow(scopes: ["profile"], entrypoint: "junk", metrics: nil)))
+        //
         // Try to make a logins DB.
-        let loginsDbPath = profilePath.flatMap {
-            URL(fileURLWithPath: $0).appendingPathComponent("logins.db").path
-        }
-        let loginsStore = LoginsStorage(databasePath: loginsDbPath!)
-        try! loginsStore.unlockWithKeyAndSalt(key: "secret", salt: "00000000000000000000000000000000")
-        if try! loginsStore.list().count == 0 {
-            print("adding login: " + (try! loginsStore.add(login: Login(
-                id: "foobar",
-                hostname: "https://example.com",
-                password: "supersekrit",
-                username: "myUser",
-                httpRealm: nil,
-                formSubmitUrl: "https://example.com/login",
-                usernameField: "",
-                passwordField: "",
-                timesUsed: 0,
-                timeCreated: 0,
-                timeLastUsed: 0,
-                timePasswordChanged: 0
-            ))))
-        }
-        print("stored logins: \(try! loginsStore.list())")
+        //let loginsDbPath = profilePath.flatMap {
+        //    URL(fileURLWithPath: $0).appendingPathComponent("logins.db").path
+        //}
+        //let loginsStore = LoginsStorage(databasePath: loginsDbPath!)
+        //try! loginsStore.unlockWithKeyAndSalt(key: "secret", salt: "00000000000000000000000000000000")
+        //if try! loginsStore.list().count == 0 {
+        //    print("adding login: " + (try! loginsStore.add(login: Login(
+        //        id: "foobar",
+        //        hostname: "https://example.com",
+        //        password: "supersekrit",
+        //        username: "myUser",
+        //        httpRealm: nil,
+        //        formSubmitUrl: "https://example.com/login",
+        //        usernameField: "",
+        //        passwordField: "",
+        //        timesUsed: 0,
+        //        timeCreated: 0,
+        //        timeLastUsed: 0,
+        //        timePasswordChanged: 0
+        //    ))))
+        //}
+        //print("stored logins: \(try! loginsStore.list())")
     }
 
     func presentModal(viewController: UIViewController, animated: Bool) {

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -6,6 +6,8 @@ import UIKit
 import Telemetry
 import Glean
 import Nimbus
+import FxAClient
+import Logins
 import Viaduct
 import RustLog
 
@@ -406,26 +408,13 @@ extension AppDelegate {
 
         Glean.shared.initialize(uploadEnabled: Settings.getToggle(.sendAnonymousUsageData))
 
-        // Just seeing if we can use the Nimbus API, this isn't really expected
-        // to *do* anything just yet.
-        let profilePath = FileManager.default.containerURL(
-                forSecurityApplicationGroupIdentifier: AppInfo.sharedContainerIdentifier
-            )?
-            .appendingPathComponent("profile.profile")
-            .path
-        let dbPath = profilePath.flatMap {
-            URL(fileURLWithPath: $0).appendingPathComponent("nimbus.db").path
-        }
-        let myNimbus = try! Nimbus.create(
-            NimbusServerSettings(url: URL(string: "https://firefox.settings.services.mozilla.com")!),
-            appSettings: NimbusAppSettings(appName: "Focus", channel: "Nightly"),
-            dbPath: dbPath!,
-            resourceBundles: [],
-            errorReporter: { err in
-                try! { err in throw err }(err)
-            }
-        )
-        Viaduct.shared.useReqwestBackend()
+        // Proof-of-Concept application-services guff here.
+        //
+        // We're just seeing if we can successfully import and use various application-services
+        // components, they don't really do anything in the app yet.
+        //
+        
+        // Hook up basic logging.
         if !RustLog.shared.tryEnable({ (level, tag, message) -> Bool in
             let logString = "[RUST][\(tag ?? "no-tag")] \(message)"
             print(logString)
@@ -433,8 +422,63 @@ extension AppDelegate {
         }) {
             print("ERROR: Unable to enable logging from Rust")
         }
+        
+        // Enable networking.
+        Viaduct.shared.useReqwestBackend()
+        
+        // Try to initialize and use Nimbus SDK.
+        let profilePath = FileManager.default.containerURL(
+                forSecurityApplicationGroupIdentifier: AppInfo.sharedContainerIdentifier
+            )?
+            .appendingPathComponent("profile.profile")
+            .path
+        let nimbusDbPath = profilePath.flatMap {
+            URL(fileURLWithPath: $0).appendingPathComponent("nimbus.db").path
+        }
+        let myNimbus = try! Nimbus.create(
+            NimbusServerSettings(url: URL(string: "https://firefox.settings.services.mozilla.com")!),
+            appSettings: NimbusAppSettings(appName: "Focus", channel: "Nightly"),
+            dbPath: nimbusDbPath!,
+            resourceBundles: [],
+            errorReporter: { err in
+                try! { err in throw err }(err)
+            }
+        )
         myNimbus.initialize()
         myNimbus.fetchExperiments()
+        
+        // Try to create an FxA Client object
+        let fxa = FirefoxAccount(
+            contentUrl: "https://accounts.firefox.com",
+            clientId: "junk",
+            redirectUri: "junk",
+            tokenServerUrlOverride: nil
+        )
+        print("fxa oauth URL: " + (try! fxa.beginOauthFlow(scopes: ["profile"], entrypoint: "junk", metrics: nil)))
+        
+        // Try to make a logins DB.
+        let loginsDbPath = profilePath.flatMap {
+            URL(fileURLWithPath: $0).appendingPathComponent("logins.db").path
+        }
+        let loginsStore = LoginsStorage(databasePath: loginsDbPath!)
+        try! loginsStore.unlockWithKeyAndSalt(key: "secret", salt: "00000000000000000000000000000000")
+        if try! loginsStore.list().count == 0 {
+            print("adding login: " + (try! loginsStore.add(login: Login(
+                id: "foobar",
+                hostname: "https://example.com",
+                password: "supersekrit",
+                username: "myUser",
+                httpRealm: nil,
+                formSubmitUrl: "https://example.com/login",
+                usernameField: "",
+                passwordField: "",
+                timesUsed: 0,
+                timeCreated: 0,
+                timeLastUsed: 0,
+                timePasswordChanged: 0
+            ))))
+        }
+        print("stored logins: \(try! loginsStore.list())")
     }
 
     func presentModal(viewController: UIViewController, animated: Bool) {


### PR DESCRIPTION
This uses the experimental swift package for Nimbus from https://github.com/rfk/rust-components-swift to do a proof-of-concept Nimbus integration into focus-ios.

@skhamis could you please try this out on your M1 mac and see if it builds and runs cleanly? In theory, it should be as simple as:

* Checkout this branch
* Open `Blockzilla.xcodeproj` in xcode
* Build and run it on the simulator
* Check the debug logging output from the app to see if it says anything about "nimbus"

The binary artifact used by https://github.com/rfk/rust-components-swift *should* have the necessary code in it to work on the M1, will be interesting to see how that goes in practice :-)